### PR TITLE
implemented skip-confirmation option

### DIFF
--- a/lib/master_delivery.rb
+++ b/lib/master_delivery.rb
@@ -69,13 +69,13 @@ module MasterDelivery
       backup_dir
     end
 
-    def confirm(master_id, target_prefix, type: :symbolic_link, dryrun: false)
-      puts MSG_CONFIRMATION_INTRO
+    def confirm(master_id, target_prefix, type: :symbolic_link, dryrun: false, skip_conf: false)
+      puts MSG_CONFIRMATION_INTRO unless skip_conf
 
       print_params(master_id, target_prefix, type: type, dryrun: dryrun)
       print_sample(master_id, target_prefix)
-      print MSG_CONFIRMATION.chomp # use print instead of puts for '\n'
-      return true if gets.chomp == 'y'
+      print MSG_CONFIRMATION.chomp unless skip_conf # use print instead of puts for '\n'
+      return true if skip_conf || gets.chomp == 'y'
 
       false
     end


### PR DESCRIPTION
close #3 

- Described the danger carefully in the help
```
    Skip confirmation. It is recommended to execute
    the command carefully without skipping confirmation.
    With the "--yes" option, if you want to change the
    command line argument even a little, remove the
    "--yes" option once, execute it several times,
    and experience confirmation several times.
    Also, it's a good idea to add the "--yes" option
    only after you start to feel confirmation annoying.
     (default: --no-yes)
```