### PR TITLE
Feature/#5 trace delivery commands

### DIFF
--- a/spec/test/log.bkp
+++ b/spec/test/log.bkp
@@ -32,4 +32,4 @@ Sample (from 6 master files):
 master:            /Users/shinya.ohtani/unix/cloned/master_delivery/spec/test/sample01/.c
 will be delivered: /Users/shinya.ohtani/unix/cloned/master_delivery/spec/test/sandbox/.c
  and backup:       /Users/shinya.ohtani/unix/cloned/master_delivery/sample01-original-XXXX/.c
-done!
+done! (6 master files are delivered.)


### PR DESCRIPTION
close #5 
- Verbose mode is implemented
  - Use Option `{:verbose}` for method calls on FileUtils
  - On Dir.mktmpdir, I used puts after tempdir is created.

- `done!` message is slightly updated
  - --> `done! (6 master files are delivered.)`